### PR TITLE
Torznab: configurable Global/Kad fallback instead of always waiting for both (#89)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,14 @@ PORT=4000
 # Delay (in milliseconds) between searches to avoid ED2K server flood protection
 # Default: 5000ms (5 seconds). Increase if you experience connection issues.
 # ED2K_SEARCH_DELAY_MS=10000
+#
+# Which networks a Torznab search queries, and in which order.
+# Default: global-first (Global, then Kad only if Global returned nothing).
+# Values: global-first | kad-first | global-only | kad-only | both
+# `both` is the old sequential merge and is rarely a good fit for *arr
+# clients with a ~30s HTTP timeout. kad-first is available but not the
+# default without a Kad-vs-Global timing comparison on your workload.
+# ED2K_SEARCH_NETWORK_STRATEGY=global-first
 
 # ED2K Search Cache
 # Cache search results to handle Sonarr pagination (offset/limit) without duplicate searches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 🐛 Fixed
+
+- **Torznab no longer waits for Kad after Global already found files.** *arr clients with a ~30s HTTP timeout were still waiting for the second network after the first had a result, so the feed arrived after the client had given up. The default is now `global-first`: Global, then Kad only if Global was empty. The previous sequential merge remains as `both`. Kad-first, Global-only and Kad-only are also configurable via `ED2K_SEARCH_NETWORK_STRATEGY`. If the HTTP client disconnects, the next network is not started; a search already running in aMule cannot be cancelled over EC (#89).
+
+---
+
 ## [3.9.3] - Searches That Reach aMule
 
 ### 🐛 Fixed

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -344,6 +344,7 @@ services:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ED2K_SEARCH_DELAY_MS` | `5000` | Delay between searches (avoid flood protection) |
+| `ED2K_SEARCH_NETWORK_STRATEGY` | `global-first` | Torznab network order: `global-first`, `kad-first`, `global-only`, `kad-only`, `both` |
 | `ED2K_CACHE_TTL_MS` | `600000` | Search result cache duration |
 
 #### Advanced

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -282,6 +282,8 @@ ED2K servers have flood protection that can temporarily ban clients making too m
 - **Default:** 10 seconds between consecutive ED2K searches
 - **Configurable via:** `ED2K_SEARCH_DELAY_MS` environment variable
 - **Recommendation:** 5000-10000ms (5-10 seconds)
+- **Kad searches skip this delay.** The gap exists for ED2K server flood protection, not for Kad.
+- **Network order:** `ED2K_SEARCH_NETWORK_STRATEGY` (default `global-first`). See [CONFIGURATION.md](./CONFIGURATION.md).
 
 ---
 

--- a/server/lib/torznab/TorznabHandler.js
+++ b/server/lib/torznab/TorznabHandler.js
@@ -25,6 +25,22 @@ const { convertToTorznabFeed } = require('./search');
 // they auto-append operators; reserve headroom then.
 const MAX_AMULE_QUERY_WORDS = 11;
 
+// Torznab is a synchronous HTTP search. *arr clients often time out at ~30s,
+// while aMule has one search slot and each network can take far longer.
+// `both` (Global then Kad, always) is what missed those clients: the first
+// network could already have the file, and the second still ran (#89).
+// Default is fallback-on-empty with Global first — the only order we have
+// timings for. Kad-first is available for operators who want to spare ED2K
+// servers; it is not the default without a Kad-vs-Global benchmark.
+const DEFAULT_NETWORK_STRATEGY = 'global-first';
+const NETWORK_STRATEGIES = {
+  'global-first': { first: 'global', second: 'kad', alwaysSecond: false },
+  'kad-first': { first: 'kad', second: 'global', alwaysSecond: false },
+  'global-only': { first: 'global', second: null, alwaysSecond: false },
+  'kad-only': { first: 'kad', second: null, alwaysSecond: false },
+  'both': { first: 'global', second: 'kad', alwaysSecond: true }
+};
+
 class TorznabHandler {
   constructor() {
     // Dependencies
@@ -38,10 +54,10 @@ class TorznabHandler {
     this.searchSettleMs = parseInt(process.env.ED2K_SEARCH_SETTLE_MS || '5000', 10);
     this.searchPollMs = parseInt(process.env.ED2K_SEARCH_POLL_MS || '1000', 10);
     this.searchTimeoutMs = parseInt(process.env.ED2K_SEARCH_TIMEOUT_MS || '120000', 10);
-    // How long a request waits for the ed2k search slot before giving up. Two
-    // searches run per request (global + kad), so a queue of *arr searches can
-    // legitimately wait a while before its turn.
+    // How long a request waits for the ed2k search slot before giving up.
+    // Distinct queries still serialize on aMule's single search slot.
     this.searchLockWaitMs = parseInt(process.env.ED2K_SEARCH_LOCK_WAIT_MS || '180000', 10);
+    this.searchNetworkStrategy = process.env.ED2K_SEARCH_NETWORK_STRATEGY || DEFAULT_NETWORK_STRATEGY;
     this.lastSearchTime = 0;
 
     // Cache state
@@ -328,6 +344,32 @@ class TorznabHandler {
   // RATE LIMITING
   // ============================================================================
 
+  isClientGone(req) {
+    return Boolean(req && (req.aborted || req.destroyed || req.socket?.destroyed));
+  }
+
+  async _waitUnlessGone(req, ms) {
+    const until = Date.now() + ms;
+    while (Date.now() < until) {
+      if (this.isClientGone(req)) return;
+      await new Promise(resolve => setTimeout(resolve, Math.min(50, until - Date.now())));
+    }
+  }
+
+  resolveNetworkStrategy() {
+    const raw = String(this.searchNetworkStrategy || DEFAULT_NETWORK_STRATEGY)
+      .toLowerCase()
+      .trim();
+    const spec = NETWORK_STRATEGIES[raw];
+    if (spec) {
+      return { name: raw, ...spec };
+    }
+    logger.warn(
+      `[Torznab] Unknown ED2K_SEARCH_NETWORK_STRATEGY "${this.searchNetworkStrategy}", using ${DEFAULT_NETWORK_STRATEGY}`
+    );
+    return { name: DEFAULT_NETWORK_STRATEGY, ...NETWORK_STRATEGIES[DEFAULT_NETWORK_STRATEGY] };
+  }
+
   /**
    * Run one aMule search without monopolising the EC connection.
    *
@@ -347,10 +389,11 @@ class TorznabHandler {
    * @param {Object} amuleClient
    * @param {string} query
    * @param {string} network - 'global' or 'kad'
+   * @param {Object} [req] - HTTP request; used only to stop waiting if the client left
    * @returns {Promise<Object>} Same shape as searchAndWaitResults()
    * @private
    */
-  async _searchWithoutBlockingEC(amuleClient, query, network) {
+  async _searchWithoutBlockingEC(amuleClient, query, network, req) {
     const manager = this.getAmuleManager?.();
 
     // Unreachable in normal operation: the client is derived from this same
@@ -362,6 +405,11 @@ class TorznabHandler {
     }
 
     return manager.withSearchLock(async () => {
+      if (this.isClientGone(req)) {
+        logger.log(`[Torznab] HTTP client gone before ${network} search start; skipping`);
+        return { resultsLength: 0, totalLength: 0, results: [] };
+      }
+
       const started = await amuleClient.startSearch(query, network, '');
       if (started && started.started === false) {
         // The query goes in the log too. A refusal is almost always about the
@@ -374,13 +422,23 @@ class TorznabHandler {
       }
 
       // aMule needs a moment before its progress figure means anything.
-      await new Promise(resolve => setTimeout(resolve, this.searchSettleMs));
+      await this._waitUnlessGone(req, this.searchSettleMs);
+      if (this.isClientGone(req)) {
+        logger.log(`[Torznab] HTTP client gone during ${network} settle; collecting partial results`);
+        return amuleClient.getSearchResults({ groupByHash: true });
+      }
 
       const deadline = Date.now() + this.searchTimeoutMs;
       while (Date.now() < deadline) {
+        // EC cannot cancel a search already running in aMule. Stop waiting
+        // for it so the lock is released, then collect whatever is there.
+        if (this.isClientGone(req)) {
+          logger.log(`[Torznab] HTTP client gone during ${network} search; collecting partial results`);
+          break;
+        }
         const status = await amuleClient.getSearchProgress();
         if (status?.complete) break;
-        await new Promise(resolve => setTimeout(resolve, this.searchPollMs));
+        await this._waitUnlessGone(req, this.searchPollMs);
       }
 
       // Read results even on timeout: a slow search still has partial results,
@@ -389,14 +447,26 @@ class TorznabHandler {
     }, { timeoutMs: this.searchLockWaitMs });
   }
 
-  async rateLimitedSearch(searchFn) {
-    const now = Date.now();
-    const timeSinceLastSearch = now - this.lastSearchTime;
+  async rateLimitedSearch(searchFn, { network, req } = {}) {
+    // ED2K servers flood-protect; Kad is DHT and does not need the gap.
+    // Skipping it on Kad is what lets a Global miss still return inside a
+    // 30s *arr timeout (#89).
+    if (network !== 'kad') {
+      const now = Date.now();
+      const timeSinceLastSearch = now - this.lastSearchTime;
 
-    if (timeSinceLastSearch < this.searchDelayMs) {
-      const waitTime = this.searchDelayMs - timeSinceLastSearch;
-      logger.log(`[Torznab] Rate limiting: waiting ${waitTime}ms before next search`);
-      await new Promise(resolve => setTimeout(resolve, waitTime));
+      if (timeSinceLastSearch < this.searchDelayMs) {
+        const waitTime = this.searchDelayMs - timeSinceLastSearch;
+        logger.log(`[Torznab] Rate limiting: waiting ${waitTime}ms before next search`);
+        const until = Date.now() + waitTime;
+        while (Date.now() < until) {
+          if (this.isClientGone(req)) {
+            logger.log('[Torznab] HTTP client gone during rate-limit wait; not starting search');
+            return { resultsLength: 0, totalLength: 0, results: [] };
+          }
+          await this._waitUnlessGone(req, Math.min(50, until - Date.now()));
+        }
+      }
     }
 
     try {
@@ -423,7 +493,7 @@ class TorznabHandler {
    * entry.
    *
    * @param {Object} amuleClient
-   * @param {Object} params - { cacheKey, primaryQuery, fallbackQuery }
+   * @param {Object} params - { cacheKey, primaryQuery, fallbackQuery, req }
    * @returns {Promise<Array>} merged results
    * @private
    */
@@ -443,28 +513,39 @@ class TorznabHandler {
   }
 
   /**
-   * Search both aMule networks and merge the results.
+   * Search aMule according to ED2K_SEARCH_NETWORK_STRATEGY.
    *
-   * ED2K = server-indexed; Kad = DHT-indexed. They cover disjoint file sets in
-   * practice, so querying both broadens hits meaningfully. Sequential through
-   * the existing rate limiter - the 10s spacing exists to avoid ED2K server
-   * flood protection; Kad does not need it but sequential keeps total time
-   * bounded and code simple.
+   * Default `global-first`: run Global, return immediately if it found
+   * anything, otherwise Kad. That matches the 3.9.3 timing where Global
+   * already had a result in ~7s while waiting for Kad still missed a 30s
+   * Torznab client (#89). `kad-first` is the inverse fallback and is not
+   * the default: without a Kad-vs-Global benchmark it can invert the
+   * timeout (Kad 30–60s while Global would have answered in seconds).
+   * `both` is the old sequential merge; keep it for operators who want
+   * the union and can wait. Torznab does not carry a reliable
+   * manual/backlog/daily flag, so this is operator config, not caller
+   * detection.
    *
    * @private
    */
-  async _runSearch(amuleClient, { cacheKey, primaryQuery, fallbackQuery }) {
-    logger.log(`[Torznab] Cache miss, searching aMule (ED2K + Kad) for key: ${cacheKey}`);
+  async _runSearch(amuleClient, { cacheKey, primaryQuery, fallbackQuery, req }) {
+    const strategy = this.resolveNetworkStrategy();
+    logger.log(`[Torznab] Cache miss, searching aMule (${strategy.name}) for key: ${cacheKey}`);
 
     const allResults = [];
     const seenHashes = new Map();   // hash → the result we kept, for name merging
 
     const runQueryOnNetwork = async (searchQuery, network, label) => {
+      if (this.isClientGone(req)) {
+        logger.log(`[Torznab] HTTP client gone; not starting ${network} search`);
+        return;
+      }
       logger.log(`[Torznab] Searching aMule ${network} for: "${searchQuery}"${label ? ` (${label})` : ''}`);
       // groupByHash: one hash can be published under several filenames and
       // the extra ones are often the better-parsed release names (#82).
-      const result = await this.rateLimitedSearch(() =>
-        this._searchWithoutBlockingEC(amuleClient, searchQuery, network)
+      const result = await this.rateLimitedSearch(
+        () => this._searchWithoutBlockingEC(amuleClient, searchQuery, network, req),
+        { network, req }
       );
       const resultCount = (result.results || []).length;
       logger.log(`[Torznab] ${network} query returned ${resultCount} results (${result.totalLength ?? resultCount} incl. alternate names)`);
@@ -488,23 +569,25 @@ class TorznabHandler {
       });
     };
 
-    const NETWORKS = ['global', 'kad'];
+    await runQueryOnNetwork(primaryQuery, strategy.first);
 
-    // Primary pass across both networks
-    for (const network of NETWORKS) {
-      await runQueryOnNetwork(primaryQuery, network);
+    if (strategy.second) {
+      const needSecond = strategy.alwaysSecond || allResults.length === 0;
+      if (!needSecond) {
+        logger.log(`[Torznab] ${strategy.first} returned ${allResults.length} result(s); skipping ${strategy.second}`);
+      } else if (this.isClientGone(req)) {
+        logger.log(`[Torznab] HTTP client gone; not starting ${strategy.second}`);
+      } else {
+        await runQueryOnNetwork(primaryQuery, strategy.second);
+      }
     }
 
-    // Fallback disabled — primary filters are permissive enough. Kept in
-    // return shape for easy re-enable if a class of releases surfaces that
-    // needs it.
-    //
-    // if (allResults.length === 0 && fallbackQuery && fallbackQuery !== primaryQuery) {
-    //   for (const network of NETWORKS) await runQueryOnNetwork(fallbackQuery, network, 'fallback');
-    // }
+    // Bare-title fallback disabled — primary filters are permissive enough.
+    // Kept in the return shape for easy re-enable if a class of releases
+    // surfaces that needs it.
     void fallbackQuery;
 
-    logger.log(`[Torznab] Total unique results after merging (ED2K + Kad): ${allResults.length}`);
+    logger.log(`[Torznab] Total unique results after merging: ${allResults.length}`);
     this.setCachedResults(cacheKey, allResults);
 
     return allResults;
@@ -622,7 +705,12 @@ class TorznabHandler {
     // Check cache
     let allResults = this.getCachedResults(cacheKey);
     if (!allResults) {
-      allResults = await this._searchOrJoinInFlight(amuleClient, { cacheKey, primaryQuery, fallbackQuery });
+      allResults = await this._searchOrJoinInFlight(amuleClient, {
+        cacheKey,
+        primaryQuery,
+        fallbackQuery,
+        req
+      });
     }
 
     // Apply pagination

--- a/server/test/torznabGlobalKadFallback.test.js
+++ b/server/test/torznabGlobalKadFallback.test.js
@@ -1,0 +1,351 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const TorznabHandler = require('../lib/torznab/TorznabHandler');
+
+// Medusa (and other *arr clients) abort the Torznab HTTP request at ~30s.
+// Always waiting for Kad after a successful Global search is what blew that
+// budget (#89): Global already had the file, Kad added nothing, and the
+// client was gone before the merged feed was sent.
+const res = () => ({ status() { return this; }, set() { return this; }, send() { return this; } });
+
+const GLOBAL_HIT = [{
+  fileHash: 'A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4',
+  fileName: 'Example.Show.Episode.Title.mkv',
+  fileSize: 1,
+  sourceCount: 2
+}];
+
+const KAD_ONLY_HIT = [{
+  fileHash: 'B1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D5',
+  fileName: 'Kad.Only.Release.mkv',
+  fileSize: 2,
+  sourceCount: 1
+}];
+
+function captureRes() {
+  const state = { body: null };
+  return {
+    status() { return this; },
+    set() { return this; },
+    send(body) { state.body = body; return this; },
+    state
+  };
+}
+
+/** Serialises searches the same way AmuleManager.withSearchLock does. */
+function makeSearchLock() {
+  let held = false;
+  const waiters = [];
+  return {
+    async withSearchLock(fn) {
+      while (held) {
+        await new Promise(resolve => waiters.push(resolve));
+      }
+      held = true;
+      try {
+        return await fn();
+      } finally {
+        held = false;
+        const next = waiters.shift();
+        if (next) next();
+      }
+    },
+    isSearchInProgress() {
+      return held;
+    }
+  };
+}
+
+/**
+ * @param {Object} opts
+ * @param {Array} [opts.globalResults]
+ * @param {Array} [opts.kadResults]
+ * @param {number} [opts.kadDelayMs] - extra delay inside Kad startSearch
+ * @param {boolean} [opts.useRealLock]
+ */
+function makeHandler({
+  globalResults = GLOBAL_HIT,
+  kadResults = KAD_ONLY_HIT,
+  kadDelayMs = 0,
+  globalDelayMs = 0,
+  strategy = 'global-first',
+  useRealLock = false
+} = {}) {
+  const handler = new TorznabHandler();
+  handler.searchNetworkStrategy = strategy;
+  const started = [];
+  const lockHolder = useRealLock ? makeSearchLock() : { withSearchLock: async (fn) => fn() };
+
+  handler.setDependencies({
+    getAmuleClient: () => ({
+      startSearch: async (query, network) => {
+        started.push({ query, network });
+        const delayMs = network === 'kad' ? kadDelayMs : globalDelayMs;
+        if (delayMs > 0) {
+          await new Promise(r => setTimeout(r, delayMs));
+        }
+        return { started: true };
+      },
+      getSearchProgress: async () => ({ complete: true }),
+      getSearchResults: async () => {
+        const last = started[started.length - 1];
+        const results = last?.network === 'kad' ? kadResults : globalResults;
+        return {
+          resultsLength: results.length,
+          totalLength: results.length,
+          results
+        };
+      }
+    }),
+    getAmuleManager: () => lockHolder
+  });
+  handler.searchDelayMs = 0;
+  handler.searchSettleMs = 0;
+  handler.stopCacheSweep();
+
+  return { handler, started, lockHolder };
+}
+
+const search = (q) => ({ query: { t: 'search', q } });
+
+describe('Torznab Global-then-Kad fallback (#89)', () => {
+  it('returns Global results without starting Kad', async () => {
+    const { handler, started } = makeHandler({ globalResults: GLOBAL_HIT });
+    const captured = captureRes();
+
+    await handler.handleRequest(search('example show episode title'), captured);
+
+    assert.deepEqual(started.map(s => s.network), ['global']);
+    assert.ok(captured.state.body.includes('Example.Show.Episode.Title.mkv'));
+    assert.ok(!captured.state.body.includes('Kad.Only.Release.mkv'));
+  });
+
+  it('falls back to Kad when Global is empty', async () => {
+    const { handler, started } = makeHandler({ globalResults: [], kadResults: KAD_ONLY_HIT });
+    const captured = captureRes();
+
+    await handler.handleRequest(search('example missing on global'), captured);
+
+    assert.deepEqual(started.map(s => s.network), ['global', 'kad']);
+    assert.ok(captured.state.body.includes('Kad.Only.Release.mkv'));
+  });
+
+  it('returns an empty feed when both networks miss', async () => {
+    const { handler, started } = makeHandler({ globalResults: [], kadResults: [] });
+    const captured = captureRes();
+
+    await handler.handleRequest(search('nothing anywhere'), captured);
+
+    assert.deepEqual(started.map(s => s.network), ['global', 'kad']);
+    assert.equal((captured.state.body.match(/<item>/g) || []).length, 0);
+  });
+
+  it('does not wait for the ED2K rate-limit gap before Kad fallback', async () => {
+    const { handler, started } = makeHandler({ globalResults: [], kadResults: KAD_ONLY_HIT });
+    handler.searchDelayMs = 10000;
+    const startedAt = Date.now();
+
+    await handler.handleRequest(search('rate limit must not apply to kad'), res());
+
+    const elapsed = Date.now() - startedAt;
+    assert.deepEqual(started.map(s => s.network), ['global', 'kad']);
+    assert.ok(elapsed < 2000, `Kad fallback waited ${elapsed}ms for the ED2K rate limiter`);
+  });
+
+  it('still rate-limits the next Global search', async () => {
+    const { handler } = makeHandler({ globalResults: GLOBAL_HIT });
+    handler.searchDelayMs = 80;
+
+    await handler.handleRequest(search('first global'), res());
+    const startedAt = Date.now();
+    await handler.handleRequest(search('second global distinct'), res());
+    const elapsed = Date.now() - startedAt;
+
+    assert.ok(elapsed >= 70, `second Global was not delayed (${elapsed}ms)`);
+  });
+});
+
+describe('search lock contention after a Global hit (#89)', () => {
+  it('releases the slot without Kad so a distinct query is not starved', async () => {
+    const kadDelayMs = 400;
+    const { handler, started } = makeHandler({
+      globalResults: GLOBAL_HIT,
+      kadDelayMs,
+      useRealLock: true
+    });
+
+    const startedAt = Date.now();
+    await Promise.all([
+      handler.handleRequest(search('example alpha'), res()),
+      handler.handleRequest(search('example bravo'), res())
+    ]);
+    const elapsed = Date.now() - startedAt;
+
+    assert.deepEqual(started.map(s => s.network), ['global', 'global']);
+    assert.ok(
+      elapsed < kadDelayMs,
+      `distinct queries waited ${elapsed}ms; Kad would have held the lock ${kadDelayMs}ms`
+    );
+    assert.equal(handler.getAmuleManager().isSearchInProgress(), false);
+  });
+
+  it('lets a second distinct search start as soon as Global of the first finishes', async () => {
+    const { handler, started, lockHolder } = makeHandler({
+      globalResults: GLOBAL_HIT,
+      useRealLock: true
+    });
+
+    const first = handler.handleRequest(search('example alpha'), res());
+    await new Promise(r => setImmediate(r));
+    const second = handler.handleRequest(search('example bravo'), res());
+    await Promise.all([first, second]);
+
+    assert.equal(started.length, 2);
+    assert.ok(started.every(s => s.network === 'global'));
+    assert.equal(lockHolder.isSearchInProgress(), false);
+  });
+});
+
+describe('ED2K_SEARCH_NETWORK_STRATEGY (#89)', () => {
+  it('kad-first returns Kad results without starting Global', async () => {
+    const { handler, started } = makeHandler({
+      strategy: 'kad-first',
+      globalResults: GLOBAL_HIT,
+      kadResults: KAD_ONLY_HIT
+    });
+    const captured = captureRes();
+
+    await handler.handleRequest(search('example kad first hit'), captured);
+
+    assert.deepEqual(started.map(s => s.network), ['kad']);
+    assert.ok(captured.state.body.includes('Kad.Only.Release.mkv'));
+    assert.ok(!captured.state.body.includes('Example.Show.Episode.Title.mkv'));
+  });
+
+  it('kad-first falls back to Global when Kad is empty', async () => {
+    const { handler, started } = makeHandler({
+      strategy: 'kad-first',
+      globalResults: GLOBAL_HIT,
+      kadResults: []
+    });
+    const captured = captureRes();
+
+    await handler.handleRequest(search('example kad miss'), captured);
+
+    assert.deepEqual(started.map(s => s.network), ['kad', 'global']);
+    assert.ok(captured.state.body.includes('Example.Show.Episode.Title.mkv'));
+  });
+
+  it('global-only never starts Kad', async () => {
+    const { handler, started } = makeHandler({
+      strategy: 'global-only',
+      globalResults: [],
+      kadResults: KAD_ONLY_HIT
+    });
+    const captured = captureRes();
+
+    await handler.handleRequest(search('example global only miss'), captured);
+
+    assert.deepEqual(started.map(s => s.network), ['global']);
+    assert.equal((captured.state.body.match(/<item>/g) || []).length, 0);
+  });
+
+  it('kad-only never starts Global', async () => {
+    const { handler, started } = makeHandler({
+      strategy: 'kad-only',
+      globalResults: GLOBAL_HIT,
+      kadResults: KAD_ONLY_HIT
+    });
+    const captured = captureRes();
+
+    await handler.handleRequest(search('example kad only'), captured);
+
+    assert.deepEqual(started.map(s => s.network), ['kad']);
+    assert.ok(captured.state.body.includes('Kad.Only.Release.mkv'));
+  });
+
+  it('both merges Global and Kad even when Global already had a hit', async () => {
+    const { handler, started } = makeHandler({
+      strategy: 'both',
+      globalResults: GLOBAL_HIT,
+      kadResults: KAD_ONLY_HIT
+    });
+    const captured = captureRes();
+
+    await handler.handleRequest(search('example both merge'), captured);
+
+    assert.deepEqual(started.map(s => s.network), ['global', 'kad']);
+    assert.ok(captured.state.body.includes('Example.Show.Episode.Title.mkv'));
+    assert.ok(captured.state.body.includes('Kad.Only.Release.mkv'));
+  });
+
+  it('both keeps alternate names when the same hash appears on both networks', async () => {
+    const kadSameHash = [{
+      fileHash: GLOBAL_HIT[0].fileHash,
+      fileName: 'Example.Show.Alternate.Name.mkv',
+      fileSize: 1,
+      sourceCount: 3
+    }];
+    const { handler, started } = makeHandler({
+      strategy: 'both',
+      globalResults: GLOBAL_HIT,
+      kadResults: kadSameHash
+    });
+    const captured = captureRes();
+
+    await handler.handleRequest(search('example both hash dedup'), captured);
+
+    assert.deepEqual(started.map(s => s.network), ['global', 'kad']);
+    assert.equal((captured.state.body.match(/<item>/g) || []).length, 2);
+    assert.ok(captured.state.body.includes('Example.Show.Episode.Title.mkv'));
+    assert.ok(captured.state.body.includes('Example.Show.Alternate.Name.mkv'));
+  });
+
+  it('falls back to global-first for an unknown strategy name', async () => {
+    const { handler, started } = makeHandler({
+      strategy: 'not-a-mode',
+      globalResults: GLOBAL_HIT,
+      kadResults: KAD_ONLY_HIT
+    });
+
+    await handler.handleRequest(search('example unknown strategy'), res());
+
+    assert.deepEqual(started.map(s => s.network), ['global']);
+  });
+});
+
+describe('HTTP client abort (#89)', () => {
+  it('does not start Kad after Global if the client has gone', async () => {
+    const req = { query: { t: 'search', q: 'example client abort' }, aborted: false };
+    const { handler, started } = makeHandler({
+      globalResults: [],
+      kadResults: KAD_ONLY_HIT,
+      globalDelayMs: 40
+    });
+
+    const pending = handler.handleRequest(req, res());
+    const startedAt = Date.now();
+    while (started.length === 0) {
+      if (Date.now() - startedAt > 1000) {
+        throw new Error('Global search never started');
+      }
+      await new Promise(r => setImmediate(r));
+    }
+    req.aborted = true;
+    await pending;
+
+    assert.deepEqual(started.map(s => s.network), ['global']);
+  });
+
+  it('does not start any aMule search if the client is already gone', async () => {
+    const req = { query: { t: 'search', q: 'example already gone' }, aborted: true };
+    const { handler, started } = makeHandler({
+      globalResults: GLOBAL_HIT,
+      kadResults: KAD_ONLY_HIT
+    });
+
+    await handler.handleRequest(req, res());
+
+    assert.deepEqual(started, []);
+  });
+});

--- a/server/test/torznabSearchDedup.test.js
+++ b/server/test/torznabSearchDedup.test.js
@@ -57,8 +57,8 @@ describe('in-flight search deduplication', () => {
     gate.resolve();
     await requests;
 
-    // One request searches both networks, so two startSearch calls total.
-    assert.equal(started.length, 2, `ran ${started.length / 2} searches instead of 1`);
+    // Global returned a hit, so Kad is skipped: one startSearch for five joiners.
+    assert.equal(started.length, 1, `ran ${started.length} searches instead of 1`);
   });
 
   it('does not merge different queries', async () => {
@@ -72,7 +72,7 @@ describe('in-flight search deduplication', () => {
     gate.resolve();
     await requests;
 
-    assert.equal(started.length, 4, 'two distinct queries should be two searches');
+    assert.equal(started.length, 2, 'two distinct queries should be two searches');
   });
 
   it('gives every joiner the same results', async () => {
@@ -101,7 +101,7 @@ describe('in-flight search deduplication', () => {
     assert.equal(handler.inFlightSearches.size, 0, 'the in-flight entry outlived the search');
 
     await handler.handleRequest(query('example show'), res());
-    assert.equal(started.length, 2, 'the second request should have hit the cache');
+    assert.equal(started.length, 1, 'the second request should have hit the cache');
   });
 
   it('clears the key when the search fails, so the next request retries', async () => {


### PR DESCRIPTION
## Summary

- Stop waiting for the second aMule network when the first already returned files. Default is `global-first`: Global, then Kad only if Global was empty.
- `kad-first`, `global-only`, `kad-only` and `both` are available via `ED2K_SEARCH_NETWORK_STRATEGY`. `both` keeps the old sequential merge for operators who want it; it is not the default for ~30s Torznab clients.
- If the HTTP client has gone, skip the next network and stop polling. EC cannot cancel a search already running in aMule.

Closes nothing on its own; this is the leftover 3.9.3 timeout on #89 (Global hit in a few seconds, HTTP body still waited for Kad).

## Scope

- `server/lib/torznab/TorznabHandler.js` and Torznab tests
- env/docs: `ED2K_SEARCH_NETWORK_STRATEGY`
- Kad still skips the ED2K rate-limit gap; successive Global searches still wait

Out of scope (still on #89 / #93):

- Unicode query fold (#93)
- bounded waiter queue for distinct keys (no measured size yet)
- changing aMule itself

## Validation

- `node --test server/test/torznabGlobalKadFallback.test.js server/test/torznabSearchDedup.test.js` (24 passed)
- broader Torznab tests: 80 passed, 0 failed (`NODE_PATH` pointing at the parent install's `node_modules`)

## Risk

- Kad-only files are no longer returned when Global already had a different file for the same query. Operators who want the union can set `both`.
- Abort of the originating request skips the fallback for in-flight joiners of the same cache key.

## Rollback

Revert the commit or set `ED2K_SEARCH_NETWORK_STRATEGY=both` to restore sequential Global+Kad merge.